### PR TITLE
Configure Renovate - autoclosed

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>RahulGautamSingh-testing/renovate-config"
+  ]
+}


### PR DESCRIPTION
## Action Required: Fix Renovate Configuration

There is an error with this repository's Renovate configuration that needs to be fixed. As a precaution, Renovate will stop PRs until it is resolved.

Location: `renovate.json`
Error type: The renovate configuration file contains some invalid settings
Message: Configuration option `packageRules[0].labels` should be a list (Array), Configuration option `packageRules[1].labels` should be a list (Array)


Once you have resolved this problem (in this onboarding branch), Renovate will return to providing you with a preview of your repository's configuration.